### PR TITLE
Fix typo in Coursera domain name

### DIFF
--- a/cv.md
+++ b/cv.md
@@ -13,20 +13,20 @@ permalink: /cv/
 * MIT 6.00.1x: Introduction to Computer Science and Programming Using Python – <a href="https://courses.edx.org/certificates/a0da1fc2bfc745af9e3b2802105ff5dc" target="_blank">View Web Certificate</a>
 * <a href="https://www.coursera.org/learn/mathematics-and-python/home/welcome">Математика и Python для анализа данных</a> (Moscow Institute of Physics and Technology) – <a href="https://www.coursera.org/account/accomplishments/records/W82UVA27KM6U" target="_blank">View Statement of Accomplishment</a>
 * <a href="https://www.coursera.org/learn/vvedenie-mashinnoe-obuchenie/home/info">Введение в машинное обучение</a> (Higher School of Economics) – <a href="https://www.coursera.org/account/accomplishments/records/WUPNNFRC9R9U" target="_blank">View Statement of Accomplishment</a>
-* <a href="https://www.coursera.com/learn/grammar-punctuation" target="_blank">Grammar and Punctuation</a> (University of California, Irvine)
+* <a href="https://www.coursera.org/learn/grammar-punctuation" target="_blank">Grammar and Punctuation</a> (University of California, Irvine)
 * <a href="https://www.coursera.org/specializations/python">Python for Everybody Specialization</a> (University of Michigan): 
-    * <a href="https://www.coursera.com/learn/python" target="_blank">Programming for Everybody (Getting Started with Python)</a>
-    * <a href="https://www.coursera.com/learn/python-network-data" target="_blank">Using Python to Access Web Data</a>
-    * <a href="https://www.coursera.com/learn/python-databases" target="_blank">Using Databases with Python</a> – <a href="https://www.coursera.org/account/accomplishments/verify/4X7739F2GBHS" target="_blank">View Statement of Accomplishment</a>
-    * <a href="https://www.coursera.com/learn/python-data" target="_blank">Python Data Structures</a>
-* <a href="https://www.coursera.com/course/genpython" target="_blank">Python for Genomic Data Science</a> (Johns Hopkins University)
+    * <a href="https://www.coursera.org/learn/python" target="_blank">Programming for Everybody (Getting Started with Python)</a>
+    * <a href="https://www.coursera.org/learn/python-network-data" target="_blank">Using Python to Access Web Data</a>
+    * <a href="https://www.coursera.org/learn/python-databases" target="_blank">Using Databases with Python</a> – <a href="https://www.coursera.org/account/accomplishments/verify/4X7739F2GBHS" target="_blank">View Statement of Accomplishment</a>
+    * <a href="https://www.coursera.org/learn/python-data" target="_blank">Python Data Structures</a>
+* <a href="https://www.coursera.org/course/genpython" target="_blank">Python for Genomic Data Science</a> (Johns Hopkins University)
 * Data Science Specialization (Johns Hopkins University):
-    * <a href="https://www.coursera.com/course/datascitoolbox" target="_blank">The Data Scientist’s Toolbox</a> – <a href="https://www.coursera.org/account/accomplishments/records/8V5CAMQU2S2G" target="_blank">View Statement of Accomplishment</a>
-    * <a href="https://www.coursera.com/course/rprog" target="_blank">R Programming</a> – <a href="https://www.coursera.org/account/accomplishments/records/3PE2MRX6F36X" target="_blank">View Statement of Accomplishment</a>
-    * <a href="https://www.coursera.com/course/getdata" target="_blank">Getting and Cleaning Data</a>
-    * <a href="https://www.coursera.com/course/exdata" target="_blank">Exploratory Data Analysis</a>
-    * <a href="https://www.coursera.com/course/repdata" target="_blank">Reproducible Research</a>
-    * <a href="https://www.coursera.com/course/statinference" target="_blank">Statistical Inference</a>
+    * <a href="https://www.coursera.org/course/datascitoolbox" target="_blank">The Data Scientist’s Toolbox</a> – <a href="https://www.coursera.org/account/accomplishments/records/8V5CAMQU2S2G" target="_blank">View Statement of Accomplishment</a>
+    * <a href="https://www.coursera.org/course/rprog" target="_blank">R Programming</a> – <a href="https://www.coursera.org/account/accomplishments/records/3PE2MRX6F36X" target="_blank">View Statement of Accomplishment</a>
+    * <a href="https://www.coursera.org/course/getdata" target="_blank">Getting and Cleaning Data</a>
+    * <a href="https://www.coursera.org/course/exdata" target="_blank">Exploratory Data Analysis</a>
+    * <a href="https://www.coursera.org/course/repdata" target="_blank">Reproducible Research</a>
+    * <a href="https://www.coursera.org/course/statinference" target="_blank">Statistical Inference</a>
 * [Kaggle R Tutorial on Machine Learning](https://www.datacamp.com/courses/kaggle-r-tutorial-on-machine-learning)
 * [Data Analysis and Statistical Inference](https://www.datacamp.com/courses/statistical-inference-and-data-analysis)
 * [Intro to Python for Data Science](https://campus.datacamp.com/courses/intro-to-python-for-data-science)


### PR DESCRIPTION
Было `.com` вместо `.org` в нескольких местах. Хоть перенаправление и есть, оно уводит на главную страницу, вместо страницы курса.
